### PR TITLE
Rm broken link

### DIFF
--- a/docs/source/user_guide/dask_gateway.md
+++ b/docs/source/user_guide/dask_gateway.md
@@ -25,8 +25,7 @@ from dask_gateway import Gateway
 gateway = Gateway()
 ```
 
-QHub has [a
-section](https://docs.qhub.dev/en/latest/source/02_get_started/04_configuration.html#profiles)
+QHub has a section
 for configuring the dask profiles that users have access to. These can
 be accessed via dask gateway options. Once the
 [ipywidget](https://ipywidgets.readthedocs.io/en/latest/) shows up the


### PR DESCRIPTION
This link is broken. Looks like it would now refer to sections in each of the cloud provider walk-throughs.